### PR TITLE
Use tempfile for proxy UI/assets cache

### DIFF
--- a/litellm/proxy/proxy_server.py
+++ b/litellm/proxy/proxy_server.py
@@ -12,6 +12,7 @@ import time
 import traceback
 import warnings
 from datetime import datetime, timedelta
+import tempfile
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -946,7 +947,7 @@ try:
     # This prevents mutating the packaged UI directory (e.g. site-packages or the repo checkout)
     # and ensures extensionless routes like /ui/login work via <route>/index.html.
     is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-    runtime_ui_path = "/tmp/litellm_ui"
+    runtime_ui_path = os.path.join(tempfile.gettempdir(), "litellm_ui")
 
     if _dir_has_content(runtime_ui_path):
         if is_non_root:
@@ -8884,7 +8885,11 @@ def get_image():
     default_site_logo = os.path.join(current_dir, "logo.jpg")
 
     is_non_root = os.getenv("LITELLM_NON_ROOT", "").lower() == "true"
-    assets_dir = "/tmp/litellm_assets" if is_non_root else current_dir
+    assets_dir = (
+        os.path.join(tempfile.gettempdir(), "litellm_assets")
+        if is_non_root
+        else current_dir
+    )
 
     if is_non_root:
         os.makedirs(assets_dir, exist_ok=True)


### PR DESCRIPTION
## Relevant issues\n\nAddresses Bandit B108 warnings for hardcoded temp directories.\n\n## Pre-Submission checklist\n\n**Please complete all items before asking a LiteLLM maintainer to review your PR**\n\n- [ ] I have Added testing in the [`tests/litellm/`](https://github.com/BerriAI/litellm/tree/main/tests/litellm) directory, **Adding at least 1 test is a hard requirement** - [see details](https://docs.litellm.ai/docs/extras/contributing_code)\n- [ ] My PR passes all unit tests on [`make test-unit`](https://docs.litellm.ai/docs/extras/contributing_code)\n- [x] My PR's scope is as isolated as possible, it only solves 1 specific problem\n\n## CI (LiteLLM team)\n\n> **CI status guideline:**\n>\n> - 50-55 passing tests: main is stable with minor issues.\n> - 45-49 passing tests: acceptable but needs attention\n> - <= 40 passing tests: unstable; be careful with your merges and assess the risk.\n\n- [ ] **Branch creation CI run**  \n       Link: N/A\n\n- [ ] **CI run for the last commit**  \n       Link: N/A\n\n- [ ] **Merge / cherry-pick CI run**  \n       Links: N/A\n\n## Type\n\n🐛 Bug Fix\n\n## Changes\n\n- Use `tempfile.gettempdir()` for runtime UI cache directory instead of hardcoded `/tmp`.\n- Use `tempfile.gettempdir()` for non-root logo/assets cache directory instead of hardcoded `/tmp`.\n\n