### PR TITLE
feat(model_prices): add gemini-3.1-flash-lite-image

### DIFF
--- a/litellm/model_prices_and_context_window_backup.json
+++ b/litellm/model_prices_and_context_window_backup.json
@@ -18141,6 +18141,44 @@
         },
         "web_search_billing_unit": "per_query"
     },
+    "gemini-3.1-flash-lite-image": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_image": 0.00028,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0336,
+        "output_cost_per_image_token": 3e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
@@ -19948,6 +19986,42 @@
             "search_context_size_high": 0.014
         },
         "web_search_billing_unit": "per_query"
+    },
+    "gemini/gemini-3.1-flash-lite-image": {
+        "input_cost_per_image": 0.00028,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0336,
+        "output_cost_per_image_token": 3e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-lite-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_vision": true
     },
     "gemini/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
@@ -38759,6 +38833,27 @@
         "output_cost_per_token": 3e-06,
         "supports_reasoning": false,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
+    },
+    "vertex_ai/gemini-3.1-flash-lite-image": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_image": 0.00028,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0336,
+        "output_cost_per_image_token": 3e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_vision": true,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing"
     },
     "vertex_ai/gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,

--- a/model_prices_and_context_window.json
+++ b/model_prices_and_context_window.json
@@ -18141,6 +18141,44 @@
         },
         "web_search_billing_unit": "per_query"
     },
+    "gemini-3.1-flash-lite-image": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_image": 0.00028,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0336,
+        "output_cost_per_image_token": 3e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image",
+            "video"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": false,
+        "supports_pdf_input": true,
+        "supports_prompt_caching": true,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_video_input": true,
+        "supports_vision": true
+    },
     "gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,
         "input_cost_per_audio_token": 5e-07,
@@ -19948,6 +19986,42 @@
             "search_context_size_high": 0.014
         },
         "web_search_billing_unit": "per_query"
+    },
+    "gemini/gemini-3.1-flash-lite-image": {
+        "input_cost_per_image": 0.00028,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "gemini",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0336,
+        "output_cost_per_image_token": 3e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "rpm": 1000,
+        "tpm": 4000000,
+        "source": "https://ai.google.dev/gemini-api/docs/pricing#gemini-3.1-flash-lite-image",
+        "supported_endpoints": [
+            "/v1/chat/completions",
+            "/v1/completions",
+            "/v1/batch"
+        ],
+        "supported_modalities": [
+            "text",
+            "image"
+        ],
+        "supported_output_modalities": [
+            "text",
+            "image"
+        ],
+        "supports_function_calling": true,
+        "supports_prompt_caching": false,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_system_messages": true,
+        "supports_vision": true
     },
     "gemini/deep-research-pro-preview-12-2025": {
         "input_cost_per_image": 0.0011,
@@ -38759,6 +38833,27 @@
         "output_cost_per_token": 3e-06,
         "supports_reasoning": false,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing#gemini-models"
+    },
+    "vertex_ai/gemini-3.1-flash-lite-image": {
+        "cache_read_input_token_cost": 2.5e-08,
+        "input_cost_per_image": 0.00028,
+        "input_cost_per_token": 2.5e-07,
+        "input_cost_per_token_batches": 1.25e-07,
+        "litellm_provider": "vertex_ai-language-models",
+        "max_input_tokens": 65536,
+        "max_output_tokens": 4096,
+        "max_tokens": 4096,
+        "mode": "image_generation",
+        "output_cost_per_image": 0.0336,
+        "output_cost_per_image_token": 3e-05,
+        "output_cost_per_token": 1.5e-06,
+        "output_cost_per_token_batches": 7.5e-07,
+        "supports_function_calling": false,
+        "supports_prompt_caching": true,
+        "supports_reasoning": false,
+        "supports_response_schema": false,
+        "supports_vision": true,
+        "source": "https://cloud.google.com/gemini-enterprise-agent-platform/generative-ai/pricing"
     },
     "vertex_ai/gemini-3.1-flash-lite-preview": {
         "cache_read_input_token_cost": 2.5e-08,

--- a/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
+++ b/tests/test_litellm/litellm_core_utils/llm_cost_calc/test_llm_cost_calc_utils.py
@@ -1546,6 +1546,7 @@ def test_service_tier_fallback_pricing():
     [
         "gemini-3-pro-image-preview",
         "gemini-3.1-flash-image-preview",
+        "gemini-3.1-flash-lite-image",
     ],
 )
 def test_gemini_image_generation_cost_with_zero_text_tokens(model: str):

--- a/tests/test_litellm/test_gemini_3_1_flash_lite_image_model_metadata.py
+++ b/tests/test_litellm/test_gemini_3_1_flash_lite_image_model_metadata.py
@@ -1,0 +1,242 @@
+import json
+from pathlib import Path
+
+import pytest
+
+import litellm
+from litellm import completion_cost
+from litellm.cost_calculator import cost_per_token
+from litellm.litellm_core_utils.get_llm_provider_logic import get_llm_provider
+from litellm.litellm_core_utils.llm_cost_calc.utils import generic_cost_per_token
+from litellm.llms.gemini.image_generation.cost_calculator import (
+    cost_calculator as gemini_image_generation_cost_calculator,
+)
+from litellm.llms.vertex_ai.image_generation.cost_calculator import (
+    cost_calculator as vertex_image_generation_cost_calculator,
+)
+from litellm.types.utils import (
+    CompletionTokensDetailsWrapper,
+    ImageObject,
+    ImageResponse,
+    ImageUsage,
+    ImageUsageInputTokensDetails,
+    ModelResponse,
+    PromptTokensDetailsWrapper,
+    Usage,
+)
+
+REPO_ROOT = Path(__file__).parents[2]
+MAIN_PATH = REPO_ROOT / "model_prices_and_context_window.json"
+BACKUP_PATH = REPO_ROOT / "litellm" / "model_prices_and_context_window_backup.json"
+
+UNPREFIXED = "gemini-3.1-flash-lite-image"
+GEMINI = "gemini/gemini-3.1-flash-lite-image"
+VERTEX = "vertex_ai/gemini-3.1-flash-lite-image"
+ALL_KEYS = (UNPREFIXED, GEMINI, VERTEX)
+
+INPUT_COST = 2.5e-07
+INPUT_COST_BATCHES = 1.25e-07
+OUTPUT_TEXT_COST = 1.5e-06
+OUTPUT_TEXT_COST_BATCHES = 7.5e-07
+OUTPUT_IMAGE_TOKEN_COST = 3e-05
+OUTPUT_COST_PER_1K_IMAGE = 0.0336
+INPUT_COST_PER_IMAGE = 0.00028
+CACHE_READ_COST = 2.5e-08
+MAX_INPUT_TOKENS = 65536
+MAX_OUTPUT_TOKENS = 4096
+TOKENS_PER_1K_IMAGE = 1120
+
+
+def _load(path: Path) -> dict:
+    with open(path) as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def local_model_cost_map(monkeypatch):
+    original_model_cost = litellm.model_cost
+    monkeypatch.setenv("LITELLM_LOCAL_MODEL_COST_MAP", "True")
+    litellm.model_cost = litellm.get_model_cost_map(url="")
+    litellm.get_model_info.cache_clear()
+    try:
+        yield
+    finally:
+        litellm.model_cost = original_model_cost
+        litellm.get_model_info.cache_clear()
+
+
+@pytest.mark.parametrize("model", ALL_KEYS)
+def test_gemini_3_1_flash_lite_image_is_registered(model: str):
+    info = _load(MAIN_PATH).get(model)
+    assert info is not None, f"{model} not found in model_prices_and_context_window.json"
+
+    assert info["mode"] == "image_generation"
+    assert info["input_cost_per_token"] == INPUT_COST
+    assert info["input_cost_per_token_batches"] == INPUT_COST_BATCHES
+    assert info["output_cost_per_token"] == OUTPUT_TEXT_COST
+    assert info["output_cost_per_token_batches"] == OUTPUT_TEXT_COST_BATCHES
+    assert info["output_cost_per_image"] == OUTPUT_COST_PER_1K_IMAGE
+    assert info["output_cost_per_image_token"] == OUTPUT_IMAGE_TOKEN_COST
+    assert info["max_input_tokens"] == MAX_INPUT_TOKENS
+    assert info["max_output_tokens"] == MAX_OUTPUT_TOKENS
+    assert info["max_tokens"] == MAX_OUTPUT_TOKENS
+    assert info["supports_reasoning"] is False
+    assert info["supports_response_schema"] is False
+    assert info["supports_vision"] is True
+    for field in ("supports_web_search", "search_context_cost_per_query", "web_search_billing_unit"):
+        assert field not in info
+
+
+def test_gemini_3_1_flash_lite_image_provider_specific_fields():
+    cost_map = _load(MAIN_PATH)
+
+    unprefixed = cost_map[UNPREFIXED]
+    assert unprefixed["litellm_provider"] == "vertex_ai-language-models"
+    assert unprefixed["cache_read_input_token_cost"] == CACHE_READ_COST
+    assert unprefixed["input_cost_per_image"] == INPUT_COST_PER_IMAGE
+    assert unprefixed["supports_function_calling"] is False
+    assert unprefixed["supports_prompt_caching"] is True
+    assert unprefixed["supports_pdf_input"] is True
+    assert unprefixed["supports_video_input"] is True
+    assert unprefixed["supported_modalities"] == ["text", "image", "video"]
+
+    gemini = cost_map[GEMINI]
+    assert gemini["litellm_provider"] == "gemini"
+    assert gemini["supports_function_calling"] is True
+    assert gemini["supports_prompt_caching"] is False
+    assert "cache_read_input_token_cost" not in gemini
+    assert gemini["supported_modalities"] == ["text", "image"]
+    assert gemini["supported_output_modalities"] == ["text", "image"]
+    assert gemini["rpm"] == 1000
+    assert gemini["tpm"] == 4000000
+    assert gemini["input_cost_per_image"] == INPUT_COST_PER_IMAGE
+
+    vertex = cost_map[VERTEX]
+    assert vertex["litellm_provider"] == "vertex_ai-language-models"
+    assert vertex["cache_read_input_token_cost"] == CACHE_READ_COST
+    assert vertex["input_cost_per_image"] == INPUT_COST_PER_IMAGE
+    assert vertex["supports_function_calling"] is False
+    assert vertex["supports_prompt_caching"] is True
+
+
+def test_one_k_image_price_matches_official_token_math():
+    assert TOKENS_PER_1K_IMAGE * OUTPUT_IMAGE_TOKEN_COST == OUTPUT_COST_PER_1K_IMAGE
+    assert TOKENS_PER_1K_IMAGE * INPUT_COST == INPUT_COST_PER_IMAGE
+
+
+@pytest.mark.parametrize("model", ALL_KEYS)
+def test_backup_matches_main(model: str):
+    main_cost = _load(MAIN_PATH)
+    backup_cost = _load(BACKUP_PATH)
+    assert backup_cost.get(model) == main_cost.get(model), f"{model} differs between main and backup model cost maps"
+
+
+def test_gemini_prefix_routes_to_gemini():
+    routed_model, provider, _, _ = get_llm_provider(model=GEMINI)
+    assert routed_model == UNPREFIXED
+    assert provider == "gemini"
+
+
+def test_vertex_prefix_routes_to_vertex():
+    routed_model, provider, _, _ = get_llm_provider(model=VERTEX)
+    assert routed_model == UNPREFIXED
+    assert provider == "vertex_ai"
+
+
+def test_text_token_cost(local_model_cost_map):
+    prompt_cost, text_completion_cost = cost_per_token(model=GEMINI, prompt_tokens=1000, completion_tokens=500)
+    assert prompt_cost == pytest.approx(1000 * INPUT_COST)
+    assert text_completion_cost == pytest.approx(500 * OUTPUT_TEXT_COST)
+
+
+def test_completion_cost_bills_one_k_image(local_model_cost_map):
+    response = ModelResponse()
+    response.model = UNPREFIXED
+    response.usage = Usage(
+        prompt_tokens=7,
+        completion_tokens=TOKENS_PER_1K_IMAGE,
+        total_tokens=7 + TOKENS_PER_1K_IMAGE,
+        completion_tokens_details=CompletionTokensDetailsWrapper(image_tokens=TOKENS_PER_1K_IMAGE, text_tokens=0),
+    )
+    billed = completion_cost(
+        completion_response=response,
+        model=UNPREFIXED,
+        custom_llm_provider="vertex_ai",
+    )
+    expected = TOKENS_PER_1K_IMAGE * OUTPUT_IMAGE_TOKEN_COST + 7 * INPUT_COST
+    assert billed == pytest.approx(expected)
+
+
+def test_image_tokens_are_not_billed_as_text(local_model_cost_map):
+    usage = Usage(
+        completion_tokens=1345,
+        prompt_tokens=10,
+        total_tokens=1355,
+        completion_tokens_details=CompletionTokensDetailsWrapper(
+            accepted_prediction_tokens=None,
+            audio_tokens=None,
+            reasoning_tokens=225,
+            rejected_prediction_tokens=None,
+            text_tokens=0,
+            image_tokens=TOKENS_PER_1K_IMAGE,
+        ),
+        prompt_tokens_details=PromptTokensDetailsWrapper(
+            audio_tokens=None, cached_tokens=None, text_tokens=10, image_tokens=None
+        ),
+    )
+
+    _, image_completion_cost = generic_cost_per_token(
+        model=UNPREFIXED,
+        usage=usage,
+        custom_llm_provider="vertex_ai",
+    )
+
+    expected_completion_cost = TOKENS_PER_1K_IMAGE * OUTPUT_IMAGE_TOKEN_COST + 225 * OUTPUT_TEXT_COST
+    bugged_text_only_cost = 1345 * OUTPUT_TEXT_COST
+    assert image_completion_cost > bugged_text_only_cost * 2
+    assert image_completion_cost == pytest.approx(expected_completion_cost)
+
+
+def test_gemini_image_generation_uses_token_pricing(local_model_cost_map):
+    image_response = ImageResponse(
+        data=[ImageObject(b64_json="img1")],
+        usage=ImageUsage(
+            input_tokens=50 + TOKENS_PER_1K_IMAGE,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=50,
+                image_tokens=TOKENS_PER_1K_IMAGE,
+            ),
+            output_tokens=TOKENS_PER_1K_IMAGE,
+            total_tokens=50 + TOKENS_PER_1K_IMAGE + TOKENS_PER_1K_IMAGE,
+        ),
+    )
+
+    cost = gemini_image_generation_cost_calculator(model=GEMINI, image_response=image_response)
+    expected = (50 + TOKENS_PER_1K_IMAGE) * INPUT_COST + TOKENS_PER_1K_IMAGE * OUTPUT_IMAGE_TOKEN_COST
+    assert cost == pytest.approx(expected)
+    assert cost != OUTPUT_COST_PER_1K_IMAGE
+
+
+def test_vertex_image_generation_uses_token_pricing(local_model_cost_map):
+    image_response = ImageResponse(
+        data=[ImageObject(b64_json="img1")],
+        usage=ImageUsage(
+            input_tokens=50 + TOKENS_PER_1K_IMAGE,
+            input_tokens_details=ImageUsageInputTokensDetails(
+                text_tokens=50,
+                image_tokens=TOKENS_PER_1K_IMAGE,
+            ),
+            output_tokens=TOKENS_PER_1K_IMAGE,
+            total_tokens=50 + TOKENS_PER_1K_IMAGE + TOKENS_PER_1K_IMAGE,
+        ),
+    )
+
+    cost = vertex_image_generation_cost_calculator(model=UNPREFIXED, image_response=image_response)
+    expected = (50 + TOKENS_PER_1K_IMAGE) * INPUT_COST + TOKENS_PER_1K_IMAGE * OUTPUT_IMAGE_TOKEN_COST
+    assert cost == pytest.approx(expected)
+
+
+def test_vertex_image_generation_falls_back_to_flat_image_price(local_model_cost_map):
+    image_response = ImageResponse(data=[ImageObject(b64_json="img1"), ImageObject(b64_json="img2")])
+    cost = vertex_image_generation_cost_calculator(model=UNPREFIXED, image_response=image_response)
+    assert cost == pytest.approx(2 * OUTPUT_COST_PER_1K_IMAGE)

--- a/tests/test_litellm/test_utils.py
+++ b/tests/test_litellm/test_utils.py
@@ -4312,11 +4312,13 @@ class TestVertexEmbeddingEncodingFormat:
         "vertex_ai/gemini-3-pro-image-preview",
         "vertex_ai/gemini-3.1-flash-image",
         "vertex_ai/gemini-3.1-flash-image-preview",
+        "vertex_ai/gemini-3.1-flash-lite-image",
         "gemini/gemini-2.5-flash-image",
         "gemini/gemini-3-pro-image",
         "gemini/gemini-3-pro-image-preview",
         "gemini/gemini-3.1-flash-image",
         "gemini/gemini-3.1-flash-image-preview",
+        "gemini/gemini-3.1-flash-lite-image",
     ],
 )
 def test_gemini_image_models_do_not_support_reasoning(


### PR DESCRIPTION
## TLDR

Problem this solves:

- `gemini-3.1-flash-lite-image` is missing from the model catalog
- Image calls succeed but spend is logged as $0
- Stale PRs for this model drifted off current staging

How it solves it:

- Adds unprefixed, `gemini/`, and `vertex_ai/` catalog entries
- Prices a 1K image at $0.0336 (1120 image tokens)
- Pins Vertex cache reads at $0.025/1M tokens

## User Flow

Before: a proxy admin serving Nano Banana 2 Lite sees image traffic logged at $0

1. They add a deployment whose model is `gemini/gemini-3.1-flash-lite-image`
2. A client sends POST http://localhost:4000/v1/chat/completions with `{"model":"nano-banana-2-lite","messages":[{"role":"user","content":"Generate a picture of a banana wearing sunglasses"}],"modalities":["image","text"]}`
3. The response is 200 and includes an image plus `usage.completion_tokens_details.image_tokens` of 1120
4. GET http://localhost:4000/spend/logs shows that request at `spend=0.0`
5. GET http://localhost:4000/model/info does not list 4096 max output tokens or $30/1M image-token pricing for that deployment

After: the same image call is billed at Google's published Lite image rates

1. They add the same deployment whose model is `gemini/gemini-3.1-flash-lite-image`
2. The client sends the same POST http://localhost:4000/v1/chat/completions body
3. The response is still 200 with an image and 1120 image tokens
4. GET http://localhost:4000/spend/logs shows non-zero spend, e.g. `9 * $0.25/1M + 1120 * $30/1M + text tokens * $1.50/1M`
5. GET http://localhost:4000/model/info shows `max_output_tokens: 4096`, `output_cost_per_image_token: 3e-05`, and `output_cost_per_image: 0.0336`

## Relevant issues

Fixes #31945
Fixes #32650
Supersedes #31946 and #36113

## Linear ticket

Resolves LIT-5286

## Pre-Submission checklist

- [x] I have added meaningful tests
- [ ] My PR passes all CI/CD checks (e.g., lint, format, unit tests)
- [x] My PR's scope is as isolated as possible; it only solves 1 specific problem
- [ ] I have received a Greptile **Confidence Score of at least 4/5** before requesting a maintainer review (Greptile reviews automatically once the PR is opened; only comment `@greptileai` to re-request a review after pushing changes)

## Screenshots / Proof of Fix

This environment has no Gemini or Vertex credentials, so I could not recapture a live billed image call. Reviewer can replay the same e2e used on #36113 after starting the proxy with a `nano-banana-2-lite -> gemini/gemini-3.1-flash-lite-image` deployment and `LITELLM_LOCAL_MODEL_COST_MAP=True`

```
curl -s http://localhost:4000/v1/chat/completions \
  -H 'Content-Type: application/json' -H 'Authorization: Bearer sk-1234' \
  -d '{"model":"nano-banana-2-lite","messages":[{"role":"user","content":"Generate a picture of a banana wearing sunglasses"}],"modalities":["image","text"]}'

curl -s -H 'Authorization: Bearer sk-1234' http://localhost:4000/spend/logs

curl -s -H 'Authorization: Bearer sk-1234' http://localhost:4000/model/info
```

Expected spend for a 1K image is `1120 * $30/1M` plus text and thinking tokens at `$1.50/1M` and input at `$0.25/1M`. On #36113 a live AI Studio call billed `$0.03415725` for 9 input, 370 text, and 1120 image tokens, which matches that math

Commit for this branch: `0e3f52a4c0`

## Type

🆕 New Feature

## Caveats (if any)

- `gemini/` rpm/tpm copied from `gemini-3.1-flash-image` because Google only publishes tiered limits
- `supports_reasoning` is false to match the other Gemini image catalog rows
- Thinking is listed on the model card, but image rows stay non-reasoning so the existing Gemini image test keeps holding

### Final Attestation

- [x] The tests check the right things, including the edge cases, and regressions in the respective real-world customer use-cases are not possible after this PR